### PR TITLE
Migrate to centos 8 stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.MD
+++ b/README.MD
@@ -42,7 +42,7 @@ To use convenient command line function (dodo-centos), add following code to ~/.
 
 ```bash
 function dodo-centos(){
-    local version=3
+    local version=4
     docker run -it --rm \
         -w /workdir -v "${PWD}:/workdir" \
         -v /var/run/docker.sock:/var/run/docker.sock \
@@ -55,7 +55,7 @@ To run dodo-centos as a pod in Kubernetes cluster add next code:
 
 ```bash
 function dodo-centos-k8s(){
-    local version=3
+    local version=4
     local username=$(id -u -n)
     local podname="dodo-centos-${username}"
     kubectl delete pod --ignore-not-found "${podname}"
@@ -76,7 +76,7 @@ and add following code
 
 ```powershell
 Function dodo-centos {
-  $version="3"
+  $version="4"
   docker run -it --rm `
     --privileged `
     -w /workdir -v "${PWD}:/workdir" `


### PR DESCRIPTION
Centos 8 was deprecated - https://centos.org/cl-vs-cs/

> End of Life
> As [announced in December of 2020](https://blog.centos.org/2020/12/future-is-centos-stream/), The CentOS Project has shifted focus from CentOS Linux to CentOS Stream. Here are the expected end of life (EOL) dates for our various releases.
> 
> CentOS Linux 7 EOL: 2024-06-30
> CentOS Linux 8 EOL: 2021-12-31
> CentOS Stream 8 EOL: 2024-05-31
> CentOS Stream 9 EOL: estimated 2027, dependent on RHEL9 end of “Full Support Phase”

We are using Centos 8 Stream now